### PR TITLE
Made $hidesuspicious setting TRUE by default

### DIFF
--- a/shelldetect.php
+++ b/shelldetect.php
@@ -84,7 +84,7 @@ class shellDetector {
   private $remotefingerprint = false;
 
   //settings: hide suspicious files
-  private $hidesuspicious = false;
+  private $hidesuspicious = true;
 
   //settings: type of file submission to review (0 - old one not secure but will work with allow_url_fopen = false, 1 - new one more secure but allow_url_fopen need to be true.)
   private $submitfile = 1;


### PR DESCRIPTION
Currently `$hidesuspicious` is set to be `false` by default on line 87:

```php
  private $hidesuspicious = true;
```

and the only other place where its value is set is on line 155:

```php
    if (isset($_GET['s']) && 1 == $_GET['s']) {
      $this->hidesuspicious = false;
    }
```

which means `$hidesuspicious` is forever `false`. This makes the program display A LOT of data to the screen, and more than often (in my case) renders to browser inresponsive, or even crash.